### PR TITLE
Update workflow to avoid issue with setOutput method

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1090,6 +1090,25 @@ module.exports = {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -1099,23 +1118,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
+const fs = __importStar(__webpack_require__(747));
 const core = __importStar(__webpack_require__(470));
 const semver = __importStar(__webpack_require__(876));
+const GITHUB_OUTPUT = process.env.GITHUB_OUTPUT || '';
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const currentVersion = core.getInput('current_version');
             const bumpLevel = core.getInput('level');
             const newVersion = yield bumpSemver(currentVersion, bumpLevel);
-            core.setOutput('new_version', newVersion);
+            fs.appendFileSync(GITHUB_OUTPUT, `new_version=${newVersion}\n`);
         }
         catch (e) {
             core.error(e);
@@ -1874,6 +1888,13 @@ const SemVer = __webpack_require__(65)
 const major = (a, loose) => new SemVer(a, loose).major
 module.exports = major
 
+
+/***/ }),
+
+/***/ 747:
+/***/ (function(module) {
+
+module.exports = require("fs");
 
 /***/ }),
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
+import * as fs from 'fs';
 import * as core from '@actions/core';
 import * as semver from 'semver';
+
+const GITHUB_OUTPUT = process.env.GITHUB_OUTPUT || '';
 
 async function run(): Promise<void> {
   try {
@@ -7,7 +10,7 @@ async function run(): Promise<void> {
     const bumpLevel = core.getInput('level');
 
     const newVersion = await bumpSemver(currentVersion, bumpLevel);
-    core.setOutput('new_version', newVersion);
+    fs.appendFileSync(GITHUB_OUTPUT, `new_version=${newVersion}\n`);
   } catch (e) {
     core.error(e);
     core.setFailed(e.message);


### PR DESCRIPTION
## What this PR does / Why we need it
This PR removes the use of the method `setOutput` and changes it by adding new lines to the `GITHUB_OUTPUT` file

## Which issue(s) this PR fixes
This PR solved [issue 373](https://github.com/actions-ecosystem/action-bump-semver/issues/373)

Fixes #373 
